### PR TITLE
Infer source description from popular ones associated with the URL

### DIFF
--- a/howdju-common/lib/urlTextFragments.test.ts
+++ b/howdju-common/lib/urlTextFragments.test.ts
@@ -200,6 +200,14 @@ describe("extractQuotationFromTextFragment", () => {
       )
     ).toBe("the exact text start…the exact text end");
   });
+
+  it("extracts the quotation from the text fragment with a document fragment", () => {
+    expect(
+      extractQuotationFromTextFragment(
+        "https://example.com#the-document-fragment:~:text=the%20exact%20text"
+      )
+    ).toBe("the exact text");
+  });
   it("returns the full quotation from a text fragment with a text end if doc is provided", () => {
     const dom = new JSDOM(
       `<html><body>Something eloquent about the exact text <a href="link">should include the whole text</a> to the text end and what not.</body></html>`

--- a/howdju-common/lib/urlTextFragments.ts
+++ b/howdju-common/lib/urlTextFragments.ts
@@ -11,15 +11,19 @@ export function toUrlWithFragmentFromQuotation(url: string, quotation: string) {
     return url;
   }
   const urlObj = new URL(url);
-  if (urlObj.hash.includes(FRAGMENT_DIRECTIVE)) {
-    throw new Error(`URL should not already have a text fragment: ${url}`);
+  const fragmentDirectiveIndex = urlObj.hash.indexOf(FRAGMENT_DIRECTIVE);
+  if (fragmentDirectiveIndex > -1) {
+    logger.error(`URL should not already have a text fragment: ${url}`);
   }
 
+  const hash =
+    // substring from 1 to remove the leading #.
+    fragmentDirectiveIndex > -1
+      ? urlObj.hash.substring(0, fragmentDirectiveIndex)
+      : urlObj.hash;
+
   urlObj.hash =
-    urlObj.hash +
-    FRAGMENT_DIRECTIVE +
-    "text=" +
-    cleanTextFragmentParameter(quotation);
+    hash + FRAGMENT_DIRECTIVE + "text=" + cleanTextFragmentParameter(quotation);
   return urlObj.toString();
 }
 
@@ -102,8 +106,7 @@ export function extractQuotationFromTextFragment(
   options: ExtractQuotationFromTextFragmentOptions = defaultOptions
 ): string | undefined {
   const urlObj = new URL(url);
-  const hash = urlObj.hash.replace(/^#/, "");
-  const fragmentMatch = hash.match(/^:~:(.*)$/);
+  const fragmentMatch = urlObj.hash.match(/:~:(.*)$/);
   if (!fragmentMatch) {
     return undefined;
   }

--- a/howdju-common/lib/urlTextFragments.ts
+++ b/howdju-common/lib/urlTextFragments.ts
@@ -17,7 +17,7 @@ export function toUrlWithFragmentFromQuotation(url: string, quotation: string) {
   }
 
   const hash =
-    // substring from 1 to remove the leading #.
+    // remove an existing text fragment
     fragmentDirectiveIndex > -1
       ? urlObj.hash.substring(0, fragmentDirectiveIndex)
       : urlObj.hash;

--- a/howdju-service-common/lib/initializers/servicesInit.ts
+++ b/howdju-service-common/lib/initializers/servicesInit.ts
@@ -286,7 +286,9 @@ export function servicesInitializer(provider: AwsProvider) {
     justificationsService
   );
 
-  const mediaExcerptInfosService = new MediaExcerptInfosService();
+  const mediaExcerptInfosService = new MediaExcerptInfosService(
+    provider.mediaExcerptsDao
+  );
   const emailService = new EmailService(provider.logger, provider.sesv2);
 
   provider.logger.debug("servicesInit complete");

--- a/howdju-service-common/lib/services/MediaExcerptInfosService.ts
+++ b/howdju-service-common/lib/services/MediaExcerptInfosService.ts
@@ -1,7 +1,25 @@
+import { MediaExcerptInfo, normalizeUrl } from "howdju-common";
+
+import { MediaExcerptsDao } from "../daos";
 import { requestMediaExcerptInfo } from "../requestMediaExcerptInfo";
 
 export class MediaExcerptInfosService {
-  async inferMediaExcerptInfo(url: string, quotation: string | undefined) {
-    return requestMediaExcerptInfo(url, quotation);
+  constructor(private readonly mediaExcerptsDao: MediaExcerptsDao) {}
+
+  async inferMediaExcerptInfo(
+    url: string,
+    quotation: string | undefined
+  ): Promise<MediaExcerptInfo> {
+    const mediaExcerptInfo = await requestMediaExcerptInfo(url, quotation);
+    const normalUrl = normalizeUrl(url);
+    const sourceDescriptions =
+      await this.mediaExcerptsDao.readPopularSourceDescriptions(normalUrl);
+    if (!sourceDescriptions.length) {
+      return mediaExcerptInfo;
+    }
+    return {
+      ...mediaExcerptInfo,
+      sourceDescription: sourceDescriptions[0],
+    };
   }
 }

--- a/premiser-ui/src/normalizationSchemas.ts
+++ b/premiser-ui/src/normalizationSchemas.ts
@@ -120,6 +120,24 @@ export const sourceExcerptParaphraseSchema =
     },
   });
 
+export const urlLocatorSchema = new schema.Entity<UrlLocator>("urlLocators");
+export const sourceSchema = new schema.Entity<SourceOut>("sources");
+export const sourcesSchema = new schema.Array(sourceSchema);
+export const urlLocatorsSchema = new schema.Array(urlLocatorSchema);
+export const mediaExcerptSchema = new schema.Entity<MediaExcerptOut>(
+  "mediaExcerpts",
+  {
+    locators: {
+      urlLocators: urlLocatorsSchema,
+    },
+    citations: new schema.Array({
+      source: sourceSchema,
+    }),
+    speakers: new schema.Array(persorgSchema),
+  }
+);
+export const mediaExcerptsSchema = new schema.Array(mediaExcerptSchema);
+
 export const justificationTargetSchema = new schema.Union(
   {},
   (_value, parent) => parent.type
@@ -128,6 +146,7 @@ export const justificationBasisSchema = new schema.Union(
   {
     PROPOSITION_COMPOUND: propositionCompoundSchema,
     WRIT_QUOTE: writQuoteSchema,
+    MEDIA_EXCERPT: mediaExcerptSchema,
   },
   (_value, parent) => parent.type
 );
@@ -185,24 +204,6 @@ export const contextTrailItemsSchema = new schema.Array(
     connectingEntity: connectingEntitySchema,
   })
 );
-
-export const urlLocatorSchema = new schema.Entity<UrlLocator>("urlLocators");
-export const sourceSchema = new schema.Entity<SourceOut>("sources");
-export const sourcesSchema = new schema.Array(sourceSchema);
-export const urlLocatorsSchema = new schema.Array(urlLocatorSchema);
-export const mediaExcerptSchema = new schema.Entity<MediaExcerptOut>(
-  "mediaExcerpts",
-  {
-    locators: {
-      urlLocators: urlLocatorsSchema,
-    },
-    citations: new schema.Array({
-      source: sourceSchema,
-    }),
-    speakers: new schema.Array(persorgSchema),
-  }
-);
-export const mediaExcerptsSchema = new schema.Array(mediaExcerptSchema);
 
 export const mainSearchResultSchema = {
   mediaExcerpts: mediaExcerptsSchema,

--- a/premiser-ui/src/reducers/entities.js
+++ b/premiser-ui/src/reducers/entities.js
@@ -685,7 +685,7 @@ function urlLocatorCustomizer(
 
 /** Iteratively applies customizations to an entity. */
 export function applyCustomizations(entity, ...customizations) {
-  return reduce(
+  const result = reduce(
     customizations,
     (entity, customization) => {
       const customized = customization(entity);
@@ -693,6 +693,7 @@ export function applyCustomizations(entity, ...customizations) {
     },
     entity
   );
+  return result;
 }
 
 /** Converts path to moment */
@@ -700,7 +701,8 @@ function momentConversion(path) {
   return (entity) => {
     const value = get(entity, path);
     if (value) {
-      return set(entity, path, moment(value));
+      const result = merge(entity, set({}, path, moment(value)));
+      return result;
     }
     return entity;
   };
@@ -713,7 +715,7 @@ function persorgCustomizer(oldPersorg, newPersorg, key, object, source) {
 }
 
 function mediaExcerptCustomizer(oldExcerpt, newExcerpt, key, object, source) {
-  return applyCustomizations(
+  const result = applyCustomizations(
     merge({}, oldExcerpt, newExcerpt, {
       // Create a key on citations. Since they aren't a normalizr entity, we can update them here.
       citations: newExcerpt?.citations.map((citation) => ({
@@ -723,6 +725,7 @@ function mediaExcerptCustomizer(oldExcerpt, newExcerpt, key, object, source) {
     }),
     momentConversion("created")
   );
+  return result;
 }
 
 function propositionCustomizer(


### PR DESCRIPTION
Also:

- Fix a bug that broke extracting the quotation from a text fragment link because it was normalized first
- Fix a bug that broke extracting the quotation from from a link that had a document fragment
- Log an error rather than throwing when the UI constructs a text fragment link using a URL that already has a text fragment, since some persisted URLs have not been normalized (#494)
- Fix a bug that overwrote MediaExcerpt and UrlLocator entities (without their customizations) because we hadn't configured a MediaExcerpt basis type for our Justification normalization schema.