### PR TITLE
Make top tab nav reliable

### DIFF
--- a/premiser-ui/src/App.tsx
+++ b/premiser-ui/src/App.tsx
@@ -74,6 +74,11 @@ import "./fonts.js";
 
 const tabInfos = [
   {
+    path: paths.home(),
+    text: "Home",
+    id: "landing-tab",
+  },
+  {
     path: paths.recentActivity(),
     text: t(MAIN_TABS_RECENT_ACTIVITY_TAB_NAME),
     id: "recent-activity-tab",
@@ -489,12 +494,17 @@ class App extends Component<Props> {
         className="toolbarTabs"
         align="center"
         activeIndex={activeTabIndex}
-        onActiveIndexChange={this.onTabChange}
+        onActiveIndexChange={() => {
+          /* noop because onActiveIndexChange is required. We call onTabChange below, though. */
+        }}
       >
         {map(tabInfos, (ti, i) => (
-          <Tab active={i === activeTabIndex} id={ti.id} key={ti.id}>
-            <Link to={ti.path}>{ti.text}</Link>
-          </Tab>
+          // Link must be outer element to reliably capture clicks
+          <Link to={ti.path} key={ti.id} onClick={() => this.onTabChange(i)}>
+            <Tab active={i === activeTabIndex} id={ti.id} tabIndex={i}>
+              {ti.text}
+            </Tab>
+          </Link>
         ))}
       </TabsList>
     );


### PR DESCRIPTION
I had to add another tab Home or else the active tab highlight wouldn't move away from the previous tab when I navigated home. (Besides having an explicit Home tab is probably a good idea for usability.) I actually have no idea why navigating home (say using the logo in the upper left) correctly updates the tab highlight to the Home tab. But it works.

Long term solution might be to use a different tab component that lets us control what appears on the page using react-router.

Fixes #630 