### PR TITLE
Hard-code prod entity IDs in landing page

### DIFF
--- a/howdju-common/lib/general.test.ts
+++ b/howdju-common/lib/general.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeQuotation,
   decodeQueryStringObject,
   toSlug,
+  toJson,
 } from "./general";
 
 describe("cleanWhitespace", () => {
@@ -210,5 +211,16 @@ describe("decodeQueryStringObject", () => {
     expect(() =>
       decodeQueryStringObject("foo=bar,hello=world", ["foo", "baz"])
     ).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("toJson", () => {
+  test("should stringify an object", () => {
+    expect(toJson({ a: 1, b: "2" })).toBe('{"a":1,"b":"2"}');
+  });
+  test("handles circular references", () => {
+    const obj: any = { a: 1, b: "2" };
+    obj.c = { d: obj };
+    expect(toJson(obj)).toBe('{"a":1,"b":"2","c":{"d":"[Circular]"}}');
   });
 });

--- a/howdju-common/lib/general.ts
+++ b/howdju-common/lib/general.ts
@@ -455,8 +455,21 @@ export const keysTo = (obj: { [k: string]: any }, val: any) =>
   );
 
 export const toJson = function toJson(val: any) {
-  return JSON.stringify(val);
+  return JSON.stringify(val, handleCircularReferences());
 };
+
+function handleCircularReferences() {
+  const seen = new WeakSet();
+  return (_key: string, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return "[Circular]";
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+}
 
 export const fromJson = function fromJson(json: string) {
   return JSON.parse(json);

--- a/howdju-text-fragments/dist/rangeToFragment.js
+++ b/howdju-text-fragments/dist/rangeToFragment.js
@@ -10178,6 +10178,18 @@
       return void 0;
     };
   }
+  function handleCircularReferences() {
+    const seen = /* @__PURE__ */ new WeakSet();
+    return (_key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) {
+          return "[Circular]";
+        }
+        seen.add(value);
+      }
+      return value;
+    };
+  }
   function toSlug(text) {
     if (!text) {
       return text;
@@ -10387,7 +10399,7 @@
         {}
       );
       toJson = function toJson2(val) {
-        return JSON.stringify(val);
+        return JSON.stringify(val, handleCircularReferences());
       };
       fromJson = function fromJson2(json) {
         return JSON.parse(json);

--- a/premiser-ui/src/LandingPage.tsx
+++ b/premiser-ui/src/LandingPage.tsx
@@ -1,53 +1,55 @@
-import React, { Component } from "react";
-import { Link } from "react-router-dom";
 import { FontIcon } from "@react-md/icon";
 import cloneDeep from "lodash/cloneDeep";
 import moment from "moment";
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
 
+import { makeJustificationViewModel } from "howdju-client-common";
 import {
+  brandedParse,
+  ContextTrailItem,
   JustificationBasisTypes,
-  JustificationTargetTypes,
   JustificationPolarities,
+  JustificationRef,
+  JustificationTargetTypes,
+  MediaExcerptRef,
+  MediaExcerptView,
+  PropositionCompoundRef,
   PropositionOut,
   PropositionRef,
-  JustificationRef,
-  PropositionCompoundRef,
-  WritRef,
-  WritQuoteRef,
   UrlRef,
-  ContextTrailItem,
-  brandedParse,
 } from "howdju-common";
-import { makeJustificationViewModel } from "howdju-client-common";
 
+import ContextTrail from "@/components/contextTrail/ContextTrail";
+import JustificationBranch from "./JustificationBranch";
 import paths from "./paths";
 import PropositionCard from "./PropositionCard";
-import JustificationBranch from "./JustificationBranch";
 import { combineIds } from "./viewModels";
-import ContextTrail from "@/components/contextTrail/ContextTrail";
+import TreePolarity from "./components/TreePolarity";
 
 import "./LandingPage.scss";
+import MediaExcerptCard from "./components/mediaExcerpts/MediaExcerptCard";
 
 export default class LandingPage extends Component {
   render() {
     const created = moment.utc("2017-01-12");
     const id = "landing-page";
     const rootProposition: PropositionOut = {
-      ...PropositionRef.parse({ id: "example" }),
+      ...PropositionRef.parse({ id: "1416" }),
       text: "By law, no building in Washington, D.C. may be taller than the Capitol building",
       normalText:
         "By law, no building in Washington, D.C. may be taller than the Capitol building",
       created,
     };
     const proJustificationProposition: PropositionOut = {
-      ...PropositionRef.parse({ id: "example" }),
+      ...PropositionRef.parse({ id: "1421" }),
       text: "The 1899 Height of Buildings Act established that no building could be taller than the Capitol (289 feet)",
       normalText:
         "The 1899 Height of Buildings Act established that no building could be taller than the Capitol (289 feet)",
       created,
     };
     const proJustification = makeJustificationViewModel({
-      ...JustificationRef.parse({ id: "example" }),
+      ...JustificationRef.parse({ id: "2573" }),
       polarity: "POSITIVE",
       target: {
         type: JustificationTargetTypes.PROPOSITION,
@@ -67,8 +69,89 @@ export default class LandingPage extends Component {
       },
       created,
     });
+    const creator = { id: "example-user", longName: "The Creator" };
+    const creatorUserId = "example";
+    const proMediaExcerpt: MediaExcerptView = {
+      ...MediaExcerptRef.parse({ id: "1976" }),
+      localRep: {
+        quotation:
+          "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
+        normalQuotation:
+          "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
+      },
+      speakers: [],
+      creator,
+      locators: {
+        urlLocators: [
+          {
+            id,
+            creatorUserId,
+            key: "url-locator-original",
+            autoConfirmationStatus: {
+              status: "PREVIOUSLY_FOUND",
+              earliestFoundAt: moment(),
+              latestFoundAt: moment(),
+              earliestNotFoundAt: moment(),
+              latestNotFoundAt: moment(),
+              foundQuotation:
+                "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
+            },
+            created,
+            creator,
+            mediaExcerptId: "1436",
+            url: brandedParse(UrlRef, {
+              id: "example",
+              url: "https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
+              canonicalUrl:
+                "https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
+            }),
+          },
+          {
+            id,
+            creatorUserId,
+            key: "url-locator-archive",
+            autoConfirmationStatus: {
+              status: "FOUND",
+              earliestFoundAt: moment(),
+              latestFoundAt: moment(),
+              foundQuotation:
+                "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
+            },
+            created,
+            creator,
+            mediaExcerptId: "1436",
+            url: brandedParse(UrlRef, {
+              id: "example",
+              url: "https://web.archive.org/web/20210512170410/https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
+              canonicalUrl:
+                "https://web.archive.org/web/20210512170410/https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
+            }),
+          },
+        ],
+      },
+      citations: [
+        {
+          created,
+          mediaExcerptId: "1436",
+          creatorUserId,
+          key: "citation-example",
+          source: {
+            id: "example",
+            creator,
+            creatorUserId: "example",
+            description:
+              "“Vantage Point: The Curse of (Certain) Tall Buildings” — The American Surveyor (January 2009)",
+            normalDescription:
+              "“Vantage Point: The Curse of (Certain) Tall Buildings” — The American Surveyor (January 2009)",
+            created,
+          },
+        },
+      ],
+      created,
+      creatorUserId: "test-user",
+    };
     const proJustificationJustification = makeJustificationViewModel({
-      ...JustificationRef.parse({ id: "example" }),
+      ...JustificationRef.parse({ id: "1897" }),
       created,
       target: {
         type: JustificationTargetTypes.PROPOSITION,
@@ -76,32 +159,20 @@ export default class LandingPage extends Component {
       },
       polarity: JustificationPolarities.POSITIVE,
       basis: {
-        type: "WRIT_QUOTE",
-        entity: {
-          ...WritQuoteRef.parse({ id: "example" }),
-          quoteText:
-            "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
-          writ: {
-            ...WritRef.parse({ id: "example" }),
-            title:
-              "Vantage Point: The Curse of (Certain) Tall Buildings — The American Surveyor",
-            created,
-          },
-          urls: [
-            brandedParse(UrlRef, {
-              id: "example",
-              url: "https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
-              canonicalUrl:
-                "https://archive.amerisurv.com/PDF/TheAmericanSurveyor_Lathrop-TallBuildings_January2009.pdf",
-            }),
-          ],
-          created,
-          creatorUserId: "test-user",
-        },
+        type: "MEDIA_EXCERPT",
+        entity: proMediaExcerpt,
       },
     });
 
     const proTrailItems: ContextTrailItem[] = [
+      {
+        connectingEntity: proJustification,
+        connectingEntityId: proJustification.id,
+        connectingEntityType: "JUSTIFICATION",
+        polarity: proJustification.polarity,
+      },
+    ];
+    const proProTrailItems: ContextTrailItem[] = [
       {
         connectingEntity: proJustification,
         connectingEntityId: proJustification.id,
@@ -117,14 +188,14 @@ export default class LandingPage extends Component {
     ];
 
     const conJustificationProposition: PropositionOut = {
-      ...PropositionRef.parse({ id: "example" }),
+      ...PropositionRef.parse({ id: "1424" }),
       text: "In general, buildings in Washington, D.C. may be no taller than the width of their adjacent street plus 20 feet ",
       normalText:
         "In general, buildings in Washington, D.C. may be no taller than the width of their adjacent street plus 20 feet ",
       created,
     };
     const conJustification = makeJustificationViewModel({
-      ...JustificationRef.parse({ id: "example" }),
+      ...JustificationRef.parse({ id: "1905" }),
       created,
       target: {
         type: JustificationTargetTypes.PROPOSITION,
@@ -144,6 +215,62 @@ export default class LandingPage extends Component {
         },
       },
     });
+    const conMediaExcerpt: MediaExcerptView = {
+      ...MediaExcerptRef.parse({ id: "1441" }),
+      created,
+      localRep: {
+        quotation:
+          "No building shall be erected, altered, or raised in the District of Columbia in any manner so as to exceed in height above the sidewalk the width of the street, avenue, or highway in its front, increased by 20 feet",
+        normalQuotation:
+          "No building shall be erected, altered, or raised in the District of Columbia in any manner so as to exceed in height above the sidewalk the width of the street, avenue, or highway in its front, increased by 20 feet",
+      },
+      speakers: [],
+      creator,
+      locators: {
+        urlLocators: [
+          {
+            id,
+            creatorUserId,
+            key: "url-locator-example",
+            autoConfirmationStatus: {
+              status: "FOUND",
+              earliestFoundAt: moment(),
+              latestFoundAt: moment(),
+              foundQuotation:
+                "The Heights of Buildings Act of 1899 limited buildings in the District to 288 feet, the height of the Capitol building, in response to the newly erected 14-story Cairo apartment tower, then considered a monstrosity (now revered as outstandingly beautiful) towering over its Dupont Circle neighborhood.",
+            },
+            created,
+            creator,
+            mediaExcerptId: "example",
+            url: brandedParse(UrlRef, {
+              id: "example",
+              url: "https://code.dccouncil.gov/us/dc/council/code/sections/6-601.05",
+              canonicalUrl:
+                "https://code.dccouncil.gov/us/dc/council/code/sections/6-601.05",
+            }),
+          },
+        ],
+      },
+      citations: [
+        {
+          created,
+          mediaExcerptId: "1976",
+          creatorUserId,
+          key: "citation-example",
+          source: {
+            id: "example",
+            creator,
+            creatorUserId: "example",
+            description:
+              "DC Code - § 6–601.05. Street width to control building height; business streets; residence streets; specified properties; structures above top story of building.",
+            normalDescription:
+              "DC Code - § 6–601.05. Street width to control building height; business streets; residence streets; specified properties; structures above top story of building.",
+            created,
+          },
+        },
+      ],
+      creatorUserId: "test-user",
+    };
     const conJustificationJustification = makeJustificationViewModel({
       ...JustificationRef.parse({ id: "example" }),
       created,
@@ -153,32 +280,20 @@ export default class LandingPage extends Component {
         entity: conJustificationProposition,
       },
       basis: {
-        type: "WRIT_QUOTE",
-        entity: {
-          ...WritQuoteRef.parse({ id: "example" }),
-          created,
-          quoteText:
-            "No building shall be erected, altered, or raised in the District of Columbia in any manner so as to exceed in height above the sidewalk the width of the street, avenue, or highway in its front, increased by 20 feet",
-          writ: {
-            ...WritRef.parse({ id: "example" }),
-            created,
-            title:
-              "DC Code - § 6–601.05. Street width to control building height; business streets; residence streets; specified properties; structures above top story of building.",
-          },
-          urls: [
-            brandedParse(UrlRef, {
-              id: "example",
-              url: "https://code.dccouncil.gov/us/dc/council/code/sections/6-601.05",
-              canonicalUrl:
-                "https://code.dccouncil.gov/us/dc/council/code/sections/6-601.05",
-            }),
-          ],
-          creatorUserId: "test-user",
-        },
+        type: "MEDIA_EXCERPT",
+        entity: conMediaExcerpt,
       },
     });
 
     const conTrailItems: ContextTrailItem[] = [
+      {
+        connectingEntity: conJustification,
+        connectingEntityId: conJustification.id,
+        connectingEntityType: "JUSTIFICATION",
+        polarity: conJustification.polarity,
+      },
+    ];
+    const conConTrailItems: ContextTrailItem[] = [
       {
         connectingEntity: conJustification,
         connectingEntityId: conJustification.id,
@@ -209,11 +324,11 @@ export default class LandingPage extends Component {
             {
               propositionCompoundId: "example",
               entity: {
-                ...PropositionRef.parse({ id: "example" }),
+                ...PropositionRef.parse({ id: "1420" }),
                 created,
-                text: "The 1910 Height of Buildings Act amended the 1899 act to base the height restriction on the width of adjacent streets.",
+                text: "The Height of Buildings Act of 1910 limits the height of buildings in Washington, D.C. based upon the width of a building's adjacent streets",
                 normalText:
-                  "The 1910 Height of Buildings Act amended the 1899 act to base the height restriction on the width of adjacent streets.",
+                  "The Height of Buildings Act of 1910 limits the height of buildings in Washington, D.C. based upon the width of a building's adjacent streets",
               },
             },
           ],
@@ -246,23 +361,20 @@ export default class LandingPage extends Component {
 
         <div className="banner">
           <div className="banner-content">
-            <PropositionCard
-              id={combineIds(
-                id,
-                "justified-proposition-example",
-                "proposition"
-              )}
-              style={{ width: "100%" }}
-              proposition={rootProposition}
-              showStatusText={false}
-            />
-            <JustificationBranch
-              justification={proJustification}
-              doShowBasisJustifications={false}
-              doShowControls={false}
-              showStatusText={false}
-              showBasisUrls={false}
-            />
+            <ContextTrail id="pro-context-trail" trailItems={proTrailItems} />
+            <TreePolarity polarity="POSITIVE">
+              <PropositionCard
+                id={combineIds(
+                  id,
+                  "justified-proposition-example",
+                  "proposition"
+                )}
+                contextTrailItems={proTrailItems}
+                style={{ width: "100%" }}
+                proposition={proJustificationProposition}
+                showStatusText={false}
+              />
+            </TreePolarity>
           </div>
         </div>
 
@@ -273,23 +385,20 @@ export default class LandingPage extends Component {
 
         <div className="banner">
           <div className="banner-content">
-            <PropositionCard
-              id={combineIds(
-                id,
-                "opposing-justification-example",
-                "proposition"
-              )}
-              style={{ width: "100%" }}
-              proposition={rootProposition}
-              showStatusText={false}
-            />
-            <JustificationBranch
-              justification={conJustification}
-              doShowBasisJustifications={false}
-              doShowControls={false}
-              showStatusText={false}
-              showBasisUrls={false}
-            />
+            <ContextTrail id="con-context-trail" trailItems={conTrailItems} />
+            <TreePolarity polarity="NEGATIVE">
+              <PropositionCard
+                id={combineIds(
+                  id,
+                  "opposing-justification-example",
+                  "proposition"
+                )}
+                style={{ width: "100%" }}
+                contextTrailItems={conTrailItems}
+                proposition={conJustificationProposition}
+                showStatusText={false}
+              />
+            </TreePolarity>
           </div>
         </div>
 
@@ -297,14 +406,18 @@ export default class LandingPage extends Component {
 
         <div className="banner">
           <div className="banner-content">
-            <ContextTrail id="pro-context-trail" trailItems={proTrailItems} />
-            <JustificationBranch
-              justification={proJustificationJustification}
-              doShowBasisJustifications={false}
-              doShowControls={false}
-              showStatusText={false}
-              showBasisUrls={true}
+            <ContextTrail
+              id="pro-context-trail"
+              trailItems={proProTrailItems}
             />
+            <TreePolarity polarity="POSITIVE">
+              <MediaExcerptCard
+                id="pro-evidence"
+                style={{ width: "100%" }}
+                mediaExcerpt={proMediaExcerpt}
+                showStatusText={false}
+              />
+            </TreePolarity>
           </div>
         </div>
 
@@ -312,14 +425,18 @@ export default class LandingPage extends Component {
 
         <div className="banner">
           <div className="banner-content">
-            <ContextTrail id="con-context-trail" trailItems={conTrailItems} />
-            <JustificationBranch
-              justification={conJustificationJustification}
-              doShowBasisJustifications={false}
-              doShowControls={false}
-              showStatusText={false}
-              showBasisUrls={true}
+            <ContextTrail
+              id="con-context-trail"
+              trailItems={conConTrailItems}
             />
+            <TreePolarity polarity="POSITIVE">
+              <MediaExcerptCard
+                id="con-evidence"
+                style={{ width: "100%" }}
+                mediaExcerpt={conMediaExcerpt}
+                showStatusText={false}
+              />
+            </TreePolarity>
           </div>
         </div>
 
@@ -327,18 +444,10 @@ export default class LandingPage extends Component {
 
         <div className="banner">
           <div className="banner-content">
-            <PropositionCard
-              id={combineIds(
-                id,
-                "counter-justification-example",
-                "proposition"
-              )}
-              style={{ width: "100%" }}
-              proposition={rootProposition}
-              showStatusText={false}
-            />
+            <ContextTrail id="pro-context-trail" trailItems={proTrailItems} />
             <JustificationBranch
               justification={proJustificationCountered}
+              contextTrailItems={proTrailItems}
               doShowBasisJustifications={false}
               doShowControls={false}
               showStatusText={false}


### PR DESCRIPTION
So that at least in prod the links work. Contributes to #544.