### PR TITLE
Replace react-md tabs with home grown

### DIFF
--- a/premiser-ui/src/App.scss
+++ b/premiser-ui/src/App.scss
@@ -93,14 +93,6 @@ strong {
   position: relative;
 }
 
-// Tabs that appear to be contiguous with the toolbar.  But to avoid handling the navigate ourselves, they are actually not in the toolbar
-.toolbarTabs {
-  background-color: $primary-color;
-  * {
-    color: $light-text-color;
-  }
-}
-
 .app-nav-drawer-header {
   @include center-contents;
 }

--- a/premiser-ui/src/App.tsx
+++ b/premiser-ui/src/App.tsx
@@ -65,21 +65,10 @@ import NavTabs from "./NavTabs";
 import "./App.scss";
 import "./fonts.js";
 
-// react-md tabs always require an activeTabIndex, but we want to support no
-// active tab when the user is not on a tab.
-// Using a large value causes react-md to draw the active tab indicator offscreen.
-// https://github.com/mlaursen/react-md/blob/292cebf72f7c3caa3e07542b0c7945a290666030/packages/tabs/src/useTabIndicatorStyles.ts#L42
-//
-// Only works on initial page load since react-md handles updates differently
-// and skips if there is no corresponding tab:
-// https://github.com/mlaursen/react-md/blob/292cebf72f7c3caa3e07542b0c7945a290666030/packages/tabs/src/useTabIndicatorStyles.ts#L53
-const defaultActiveTabIndex = 100;
-
 class App extends Component<Props> {
   throttledOnWindowScroll: () => void;
   windowMessageHandler?: WindowMessageHandler;
   state = {
-    activeTabIndex: defaultActiveTabIndex,
     windowPageYOffset: window.pageYOffset,
     isOverscrolledTop: false,
     isOverscrolledBottom: false,

--- a/premiser-ui/src/NavTabs.scss
+++ b/premiser-ui/src/NavTabs.scss
@@ -1,0 +1,31 @@
+@import "./colors";
+
+#nav-tabs {
+  display: flex;
+  // center tabs
+  justify-content: center;
+  background-color: $primary-color;
+}
+
+.nav-tab {
+  flex-basis: content;
+  text-transform: uppercase;
+
+  & > * {
+    // Apply the padding to the child so that the entire tab is clickable
+    padding: 10px 25px;
+    // Apply block so that the top/bottom padding has an effect.
+    display: block;
+  }
+
+  &.active {
+    border-bottom: 2px solid $secondary-color;
+  }
+
+  // Need a border-bottom for the transition out to work.
+  border-bottom: 0px solid $secondary-color;
+  -webkit-transition: border 500ms ease-out;
+  -moz-transition: border 500ms ease-out;
+  -o-transition: border 500ms ease-out;
+  transition: border 500ms ease-out;
+}

--- a/premiser-ui/src/NavTabs.tsx
+++ b/premiser-ui/src/NavTabs.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+
+import cn from "classnames";
+import { Link } from "react-router-dom";
+import { Action, Location } from "history";
+
+import { history } from "./history";
+import t, {
+  MAIN_TABS_ABOUT_TAB_NAME,
+  MAIN_TABS_RECENT_ACTIVITY_TAB_NAME,
+} from "./texts";
+import paths from "./paths";
+import { useEffect } from "react";
+import { logger } from "./logger";
+
+import "./NavTabs.scss";
+
+const tabInfos = [
+  {
+    path: paths.home(),
+    text: "Home",
+    id: "landing-tab",
+  },
+  {
+    path: paths.recentActivity(),
+    text: t(MAIN_TABS_RECENT_ACTIVITY_TAB_NAME),
+    id: "recent-activity-tab",
+  },
+  {
+    path: paths.about(),
+    text: t(MAIN_TABS_ABOUT_TAB_NAME),
+    id: "about-tab",
+  },
+];
+
+export default function NavTabs() {
+  useEffect(() => syncTabToPathname(window.location.pathname));
+
+  useEffect(
+    () =>
+      // history.listen returns the unlistener.
+      history.listen((location: Location, _action: Action) => {
+        logger.debug("onHistoryListen", location.pathname);
+        syncTabToPathname(location.pathname);
+      }),
+    []
+  );
+
+  const [activeTabIndex, setActiveTabIndex] = useState(-1);
+
+  function syncTabToPathname(pathname: string) {
+    setActiveTabIndex(tabInfos.findIndex((ti) => ti.path === pathname));
+  }
+
+  return (
+    <ul id="nav-tabs" aria-orientation="horizontal" role="tablist">
+      {tabInfos.map((ti, i) => {
+        const active = i === activeTabIndex;
+        return (
+          <li
+            key={ti.id}
+            className={cn("nav-tab", { active })}
+            role="tab"
+            aria-selected={active}
+          >
+            <Link to={ti.path}>{ti.text}</Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/premiser-ui/src/NavTabs.tsx
+++ b/premiser-ui/src/NavTabs.tsx
@@ -33,6 +33,7 @@ const tabInfos = [
   },
 ];
 
+/** A component for navigating to recommended content entry points, using a tab-like presentation. */
 export default function NavTabs() {
   useEffect(() => syncTabToPathname(window.location.pathname));
 
@@ -46,6 +47,8 @@ export default function NavTabs() {
     []
   );
 
+  // Use -1 to indicate no selected tab as a convenience. This is what findIndex
+  // will return for no matching tab.
   const [activeTabIndex, setActiveTabIndex] = useState(-1);
 
   function syncTabToPathname(pathname: string) {


### PR DESCRIPTION
react-md tabs always assume there is an active tab, which doesn't work for us because we don't have an active tab when we are viewing something for which we don't want a tab. This is related to the fact that we really only wanted the tabs for presentation, not to control the content of a tab panel.