### PR TITLE
Use toJson instead of JSON.stringify

### DIFF
--- a/howdju-common/lib/general.ts
+++ b/howdju-common/lib/general.ts
@@ -454,20 +454,23 @@ export const keysTo = (obj: { [k: string]: any }, val: any) =>
     {} as { [k: string]: typeof val }
   );
 
-export const toJson = function toJson(val: any) {
-  return JSON.stringify(val, handleCircularReferences());
+export const toJson = function toJson(
+  val: any,
+  replacer?: (key: string, value: any) => any
+) {
+  return JSON.stringify(val, handleCircularReferences(replacer));
 };
 
-function handleCircularReferences() {
+function handleCircularReferences(replacer?: (key: string, value: any) => any) {
   const seen = new WeakSet();
-  return (_key: string, value: any) => {
+  return (key: string, value: any) => {
     if (typeof value === "object" && value !== null) {
       if (seen.has(value)) {
         return "[Circular]";
       }
       seen.add(value);
     }
-    return value;
+    return replacer ? replacer(key, value) : value;
   };
 }
 

--- a/howdju-service-common/lib/initializers/parameterStore.test.ts
+++ b/howdju-service-common/lib/initializers/parameterStore.test.ts
@@ -1,3 +1,5 @@
+import { toJson } from "howdju-common";
+
 describe("parameterStore", () => {
   describe("getParameterStoreConfig", () => {
     it("should return deserialized parameters", async () => {
@@ -32,7 +34,7 @@ describe("parameterStore", () => {
         Parameters: [
           {
             Name: "/test/DATABASE_CONNECTION_INFO",
-            Value: JSON.stringify(expected.DATABASE_CONNECTION_INFO),
+            Value: toJson(expected.DATABASE_CONNECTION_INFO),
           },
         ],
       });

--- a/howdju-service-common/lib/logging/AwsLogger.js
+++ b/howdju-service-common/lib/logging/AwsLogger.js
@@ -1,14 +1,13 @@
 const util = require("util");
-
 const assign = require("lodash/assign");
 const concat = require("lodash/concat");
 const join = require("lodash/join");
 const map = require("lodash/map");
 const mapValues = require("lodash/mapValues");
 
-const { processArgs } = require("./processArgs");
+const { utcTimestamp, toJson } = require("howdju-common");
 
-const { utcTimestamp } = require("howdju-common");
+const { processArgs } = require("./processArgs");
 
 const logLevelNumbers = {
   silly: 5,
@@ -92,7 +91,7 @@ const makeJsonLogArguments = function (logLevel, logLevelNumber, ...args) {
     logRecord["data"] = data;
   }
 
-  const logRecordJson = JSON.stringify(logRecord, jsonStringifyReplacer);
+  const logRecordJson = toJson(logRecord, jsonStringifyReplacer);
   return [logRecordJson];
 };
 

--- a/howdju-service-common/lib/logging/processArgs.js
+++ b/howdju-service-common/lib/logging/processArgs.js
@@ -2,7 +2,7 @@ const isObject = require("lodash/isObject");
 const map = require("lodash/map");
 const toString = require("lodash/toString");
 
-const toFlatJson = (obj) => JSON.stringify(obj);
+const { toJson } = require("howdju-common");
 
 /*
  There are three intended logging patterns:
@@ -22,7 +22,7 @@ const processArgs = (args, doUseCarriageReturns) => {
   for (const arg of args) {
     if (isObject(arg)) {
       if (hasInterleavedMessageAndData) {
-        messageParts.push(toFlatJson(arg));
+        messageParts.push(toJson(arg));
       }
       datas.push(arg);
     } else {
@@ -32,7 +32,7 @@ const processArgs = (args, doUseCarriageReturns) => {
         // If the args have interleaved strings and objects, then the objects' JSON should be included in the message
         // Add all the previously seen objects
 
-        const datasJson = map(datas, toFlatJson);
+        const datasJson = map(datas, toJson);
         const spliceArgs = [messageParts.length, 0].concat(datasJson);
         messageParts.splice.apply(messageParts, spliceArgs);
       }

--- a/howdju-service-common/lib/serviceErrors.ts
+++ b/howdju-service-common/lib/serviceErrors.ts
@@ -24,7 +24,7 @@ export class EntityValidationError extends HowdjuApiError {
   // TODO(26): remove BespokeValidationErrors
   errors: ModelErrors<any> | BespokeValidationErrors;
   constructor(errors: ModelErrors<any> | BespokeValidationErrors) {
-    super("(EntityValidationError) " + JSON.stringify(errors));
+    super("(EntityValidationError) " + toJson(errors));
 
     this.errors = errors;
   }
@@ -43,7 +43,7 @@ export class AuthorizationError extends HowdjuApiError {
   // TODO(26): remove BespokeValidationErrors
   errors: ModelErrors<any> | BespokeValidationErrors;
   constructor(errors: ModelErrors<any> | BespokeValidationErrors) {
-    super("(AuthorizationError)" + JSON.stringify(errors));
+    super("(AuthorizationError)" + toJson(errors));
 
     this.errors = errors;
   }
@@ -89,7 +89,7 @@ export class EntityConflictError extends HowdjuApiError {
   // TODO(26): remove BespokeValidationErrors
   errors: ModelErrors<any> | BespokeValidationErrors;
   constructor(errors: ModelErrors<any> | BespokeValidationErrors) {
-    super("(EntityConflictError)" + JSON.stringify(errors));
+    super("(EntityConflictError)" + toJson(errors));
 
     this.errors = errors;
   }
@@ -100,7 +100,7 @@ export class UserActionsConflictError extends HowdjuApiError {
   // TODO(26): remove BespokeValidationErrors
   errors: ModelErrors<any> | BespokeValidationErrors;
   constructor(errors: ModelErrors<any> | BespokeValidationErrors) {
-    super("(UserActionsConflictError)" + JSON.stringify(errors));
+    super("(UserActionsConflictError)" + toJson(errors));
 
     this.errors = errors;
   }

--- a/howdju-service-common/lib/services/DevTopicMessageConsumer.ts
+++ b/howdju-service-common/lib/services/DevTopicMessageConsumer.ts
@@ -1,4 +1,4 @@
-import { TopicMessage } from "howdju-common";
+import { toJson, TopicMessage } from "howdju-common";
 
 import { UrlLocatorAutoConfirmationService } from "./UrlLocatorAutoConfirmationService";
 import { UrlsService } from "./UrlsService";
@@ -21,7 +21,7 @@ export class DevTopicMessageConsumer {
     const { type, params } = topicMessage;
     switch (type) {
       case "SEND_EMAIL":
-        console.log(`Received TopicMessage: ${JSON.stringify(topicMessage)}`);
+        console.log(`Received TopicMessage: ${toJson(topicMessage)}`);
         break;
       case "AUTO_CONFIRM_URL_LOCATOR": {
         const { urlLocatorId } = params;

--- a/howdju-service-common/lib/services/pagination.js
+++ b/howdju-service-common/lib/services/pagination.js
@@ -7,7 +7,7 @@ const last = require("lodash/last");
 const map = require("lodash/map");
 const mapKeys = require("lodash/mapKeys");
 
-const { SortDirections } = require("howdju-common");
+const { SortDirections, toJson } = require("howdju-common");
 
 /** Store the sort continuation properties with single-letter representations to cut down on the size of the payload */
 const ContinuationTokenShortPropertyNames = {
@@ -151,7 +151,7 @@ exports.decodeContinuationToken = (continuationToken) => {
 };
 
 exports.encodeContinuationToken = (continuationInfo) =>
-  URLSafeBase64.encode(new Buffer(JSON.stringify(continuationInfo)));
+  URLSafeBase64.encode(new Buffer(toJson(continuationInfo)));
 
 exports.updateContinuationInfo = (sorts, lastEntity, filters) => {
   const newSorts = map(sorts, (sort) => {

--- a/howdju-test-common/lib/TestTopicMessageSender.ts
+++ b/howdju-test-common/lib/TestTopicMessageSender.ts
@@ -1,10 +1,10 @@
-import { TopicMessage, TopicMessageSender } from "howdju-common";
+import { toJson, TopicMessage, TopicMessageSender } from "howdju-common";
 
 export class TestTopicMessageSender implements TopicMessageSender {
   topicMessages: TopicMessage[] = [];
 
   sendMessage(topicMessage: TopicMessage) {
-    console.log(`Received TopicMessage: ${JSON.stringify(topicMessage)}`);
+    console.log(`Received TopicMessage: ${toJson(topicMessage)}`);
     this.topicMessages.push(topicMessage);
     return Promise.resolve();
   }

--- a/howdju-text-fragments/dist/rangeToFragment.js
+++ b/howdju-text-fragments/dist/rangeToFragment.js
@@ -10178,16 +10178,16 @@
       return void 0;
     };
   }
-  function handleCircularReferences() {
+  function handleCircularReferences(replacer) {
     const seen = /* @__PURE__ */ new WeakSet();
-    return (_key, value) => {
+    return (key, value) => {
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return "[Circular]";
         }
         seen.add(value);
       }
-      return value;
+      return replacer ? replacer(key, value) : value;
     };
   }
   function toSlug(text) {
@@ -10398,8 +10398,8 @@
         },
         {}
       );
-      toJson = function toJson2(val) {
-        return JSON.stringify(val, handleCircularReferences());
+      toJson = function toJson2(val, replacer) {
+        return JSON.stringify(val, handleCircularReferences(replacer));
       };
       fromJson = function fromJson2(json) {
         return JSON.parse(json);

--- a/premiser-api/src/handler.ts
+++ b/premiser-api/src/handler.ts
@@ -27,6 +27,7 @@ import {
   HttpMethod,
   HttpStatusCode,
   httpStatusCodes,
+  toJson,
 } from "howdju-common";
 import {
   AppProvider,
@@ -130,7 +131,7 @@ function makeGatewayResult(
       appProvider.logger.warn("noContent response received body.  Ignoring");
     } else {
       filteredHeaders[headerKeys.CONTENT_TYPE] = "application/json";
-      bodyJson = JSON.stringify(body);
+      bodyJson = toJson(body);
     }
   }
 

--- a/premiser-ext/src/content.ts
+++ b/premiser-ext/src/content.ts
@@ -162,7 +162,6 @@ function runCommands(commands: ContentScriptCommand[]) {
 }
 
 function runCommand<T extends Exact<ContentScriptCommand, T>>(command: T) {
-  logger.trace(`difficult runCommand ${JSON.stringify({ command })}`);
   if ("postActionMessageToFrame" in command) {
     // TODO(38) remove any typecast
     forEach(command.postActionMessageToFrame, (value: any, key: any) => {
@@ -172,12 +171,6 @@ function runCommand<T extends Exact<ContentScriptCommand, T>>(command: T) {
         logger.error(`Unrecognized extensionFrame action: ${key}`);
         return;
       }
-      logger.trace(
-        `difficult postActionMessageToFrame ${JSON.stringify({
-          key,
-          value,
-        })}`
-      );
       postActionMessageToFrame(actionCreator(...(value as [any])));
     });
     return;
@@ -221,7 +214,6 @@ function routeRuntimeMessage(
       toggleSidebar();
       break;
     case "RUN_COMMANDS":
-      logger.trace(`difficult RUN_COMMANDS ${JSON.stringify({ message })}`);
       runCommands(message.payload.commands);
       break;
     default:
@@ -245,9 +237,6 @@ function annotateSelectionAndEdit() {
 
 function postActionMessageToFrame(action: actions.ExtensionFrameAction) {
   getOption("howdjuBaseUrl", (baseUrl) => {
-    logger.trace(
-      `difficult postActionMessageToFrame ${JSON.stringify({ action })}`
-    );
     doWhenFrameMessageHandlerReady((frameApi: FramePanelApi) => {
       frameApi.postMessage(
         {

--- a/premiser-ui/src/api.ts
+++ b/premiser-ui/src/api.ts
@@ -2,7 +2,7 @@ import Axios, { AxiosError, AxiosResponse, Cancel } from "axios";
 import { get, pick } from "lodash";
 import { CANCEL } from "redux-saga";
 
-import { HttpMethod, httpMethods } from "howdju-common";
+import { HttpMethod, httpMethods, toJson } from "howdju-common";
 
 import { logger } from "./logger";
 import {
@@ -75,7 +75,7 @@ const handleError = (error: Error | AxiosError | Cancel) => {
   if (Axios.isAxiosError(error)) {
     if (error.response) {
       throw newApiResponseError(
-        `Api error response ${JSON.stringify(error.response.data)}`,
+        `Api error response ${toJson(error.response.data)}`,
         identifierHeaders,
         error as AxiosResponseError
       );

--- a/premiser-ui/src/sagas/extensionSagas.ts
+++ b/premiser-ui/src/sagas/extensionSagas.ts
@@ -22,9 +22,6 @@ export function* postExtensionMessages() {
           "should not call extension action when we are not in an extension iframe."
         );
       }
-      logger.trace(
-        `difficult postExtensionMessagesWorker ${JSON.stringify({ action })}`
-      );
       try {
         // The extension's content script could be on any page, so allow any target origin ('*')
         window.parent.postMessage(domSerializationSafe(action), "*");
@@ -56,7 +53,7 @@ export function* postExtensionMessages() {
 function* repostMessage(action: Action) {
   while (true) {
     yield* delay(config.contentScriptAckDelayMs);
-    logger.trace(`repostMessage ${JSON.stringify({ action })}`);
+    logger.trace(`repostMessage ${toJson({ action })}`);
     window.parent.postMessage(action, "*");
   }
 }


### PR DESCRIPTION
After #658, the pre-prod env is getting a 502 from the API. In the logs I am unable to see the underlying error due to a circularity in the value we are trying to serialize.

```
2024-03-17T21:26:00.722Z	939768f3-f49c-4d68-96dd-a9ab9886cda8	ERROR	Invoke Error 	
{
    "errorType": "TypeError",
    "errorMessage": "Converting circular structure to JSON\n    --> starting at object with constructor 'IncomingMessage'\n    |     property 'req' -> object with constructor 'ClientRequest'\n    --- property 'res' closes the circle",
    "stack": [
        "TypeError: Converting circular structure to JSON",
        "    --> starting at object with constructor 'IncomingMessage'",
        "    |     property 'req' -> object with constructor 'ClientRequest'",
        "    --- property 'res' closes the circle",
        "    at JSON.stringify (<anonymous>)",
        "    at AwsLogger3.makeJsonLogArguments [as makeLogArguments] (/howdju-service-common/lib/logging/AwsLogger.js:95:30)",
        "    at AwsLogger3.<anonymous> (/howdju-service-common/lib/logging/AwsLogger.js:106:26)",
        "    at routeRequest (/var/src/router.ts:208:26)"
    ]
}
```